### PR TITLE
feat : Add BasicModal component

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -34,6 +34,7 @@ import {
   ReplyCommentBox,
   StatusBox,
   SearchInput,
+  BasicModal,
 } from './molecules';
 import {
   BoardList,
@@ -82,4 +83,5 @@ export {
   Divider,
   StandardInput,
   IconButton,
+  BasicModal,
 };

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -17,3 +17,4 @@ export { default as ChatUserProfile } from './ChatUserProfile';
 export { default as ReplyCommentBox } from './ReplyCommentBox';
 export { default as StatusBox } from './StatusBox';
 export { default as SearchInput } from './SearchInput';
+export { default as BasicModal } from './modal/BasicModal';


### PR DESCRIPTION
BasicModal 은 사용에 있어 자율성을 제한함. 자율성이 요구되는 modal 필요시 추가 제작 예정
참고로 BasicModal 은 root level 과 동일하도록 제작함, 언제 어디서든 modal 을 띄우면 항상 최상위에 있음
App.js에 예시로 올려놓음