### PR TITLE
fix : fcm 주석 처리 복구

### DIFF
--- a/src/shared/page/App.js
+++ b/src/shared/page/App.js
@@ -50,39 +50,39 @@ function App() {
   const dispatch = useDispatch();
 
   // Firebase Cloud Messaging
-  // const firebaseMessaging = getMessaging(firebaseApp);
-  // getToken(firebaseMessaging, {
-  //   vapidKey: process.env.REACT_APP_VAPID_KEY,
-  // })
-  //   .then((currentToken) => {
-  //     console.log(currentToken);
-  //     if (currentToken) {
-  //       apis.pushAlarm(currentToken).then((response) => {
-  //         console.log(response);
-  //       });
-  //     } else {
-  //       console.log('not alarm registered');
-  //     }
-  //   })
-  //   .catch((error) => console.log(error));
+  const firebaseMessaging = getMessaging(firebaseApp);
+  getToken(firebaseMessaging, {
+    vapidKey: process.env.REACT_APP_VAPID_KEY,
+  })
+    .then((currentToken) => {
+      console.log(currentToken);
+      if (currentToken) {
+        apis.pushAlarm(currentToken).then((response) => {
+          console.log(response);
+        });
+      } else {
+        console.log('not alarm registered');
+      }
+    })
+    .catch((error) => console.log(error));
 
-  // onMessage(firebaseMessaging, (payload) => {
-  //   console.log('foregroundMessage');
-  //   console.log(payload);
+  onMessage(firebaseMessaging, (payload) => {
+    console.log('foregroundMessage');
+    console.log(payload);
 
-  //   const date = new Date();
-  //   const now = date.getTime();
+    const date = new Date();
+    const now = date.getTime();
 
-  //   if (payload) {
-  //     dispatch(
-  //       addNotificationList({
-  //         title: payload.notification.title,
-  //         body: payload.notification.body,
-  //         createdAt: now,
-  //       }),
-  //     );
-  //   }
-  // });
+    if (payload) {
+      dispatch(
+        addNotificationList({
+          title: payload.notification.title,
+          body: payload.notification.body,
+          createdAt: now,
+        }),
+      );
+    }
+  });
 
   // Webpack production mode
   if (process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
- iOS 디바이스에서 메신저(카카오톡, 라인) 인앱 브라우저로 열었을 때 화면 렌더링 안 되는 문제 확인
- fcm 주석 처리 후 재배포 후 테스트해보았으나 동일 문제 발생